### PR TITLE
Make sure we declare our variables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ const STATE_HOLD = 2;
 const getStickFilename = () => {
 	return globAsync('/sys/class/input/event*')
 	.map((file) => {
-		fileName = path.join(file, 'device', 'name');
+		const fileName = path.join(file, 'device', 'name');
 		return fs.readFile(fileName)
 			.then((content) => {
 				return {
@@ -66,11 +66,11 @@ const emitJoystickEvent = (joystick, eventObj) => {
 };
 
 module.exports.getJoystick = () => {
-	var joystickStream;
+	let joystickStream;
 
 	return getStickFilename()
 	.then((filename) => {
-		joystick = new events.EventEmitter();
+		const joystick = new events.EventEmitter();
 
 		joystickStream = fs.createReadStream(filename);
 		joystickStream.on('data', (data) => {


### PR DESCRIPTION
There's a few vars in here that aren't declared, we just define them globally, this quick patch fixes that.

Noticed this because I tried to use `sense-joystick` in the node repl, with an existing `const joystick` variable, and this tries to write to it (which freaks out).